### PR TITLE
Open README.rst using the UTF-8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ DESC_REPLACEMENTS = {
 
 
 def long_description():
-    with open(os.path.join(SCRIPT_DIR, "README.rst")) as f:
+    with open(os.path.join(SCRIPT_DIR, "README.rst"), encoding='utf-8') as f:
         lines = f.read().splitlines()
     result = []
     for line in lines:


### PR DESCRIPTION
Traceback (most recent call last):
  File "setup.py", line 43, in <module>
    long_description=long_description(),
  File "setup.py", line 32, in long_description
    lines = f.read().splitlines()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 594: ordinal not in range(128)