### PR TITLE
Add optional GTK+3 support

### DIFF
--- a/librecaptcha/librecaptcha.py
+++ b/librecaptcha/librecaptcha.py
@@ -26,12 +26,24 @@ from urllib.parse import urlparse
 import base64
 import io
 import json
+import math
 import os
 import os.path
 import re
 import subprocess
 import sys
 import time
+
+try:
+    import gi
+    gi.require_version('Gtk', '3.0')
+    from gi.repository import Gtk, Gdk, GdkPixbuf, GObject, GLib
+    # disable gtk warnings
+    GLib.log_set_writer_func(lambda *a: GLib.LogWriterOutput.HANDLED)
+    from requests_futures.sessions import FuturesSession
+except ImportError:
+    Gtk = None
+    FuturesSession = None
 
 __version__ = "0.4.1-dev"
 
@@ -211,6 +223,207 @@ def draw_indices(image, rows, columns):
 
         draw.text(text_loc, str(i + 1), fill=(255, 255, 255), font=FONT)
 
+if Gtk:
+    class ChallengeButton(Gtk.ToggleButton):
+        def __init__(self, pixbuf):
+            Gtk.ToggleButton.__init__(self)
+            self.pixbuf = pixbuf
+            width = pixbuf.get_width()
+            height = pixbuf.get_height()
+            self.small_pixbuf = pixbuf.scale_simple(width * 0.9, height * 0.9,
+                    GdkPixbuf.InterpType.BILINEAR)
+            self.set_relief(Gtk.ReliefStyle.NONE)
+            fixed = Gtk.Fixed.new()
+            self.image = Gtk.Image.new_from_pixbuf(pixbuf)
+            self.image.set_size_request(width, height)
+            self.check = Gtk.Image.new_from_icon_name(
+                    'object-select-symbolic', Gtk.IconSize.DND)
+            self.check.set_pixel_size(24)
+            self.check.set_no_show_all(True)
+            context = self.check.get_style_context()
+            context.add_class("challenge-check")
+            fixed.put(self.image, 0, 0)
+            fixed.put(self.check, 0, 0)
+            self.add(fixed)
+            self.connect("toggled", lambda obj: self.toggle_check())
+
+        def toggle_check(self):
+            if self.get_active():
+                self.check.show()
+                self.image.set_from_pixbuf(self.small_pixbuf)
+            else:
+                self.check.hide()
+                self.image.set_from_pixbuf(self.pixbuf)
+
+    def image_to_gdk_pixbuf(image):
+        width, height = image.size
+        image_bytes = GLib.Bytes.new(image.tobytes())
+        has_alpha = image.mode == "RGBA"
+        bpp = 4 if has_alpha else 3
+        return GdkPixbuf.Pixbuf.new_from_bytes(
+                image_bytes, GdkPixbuf.Colorspace.RGB,
+                has_alpha, 8, width, height, width * bpp)
+
+    class ChallengeDialog(Gtk.Dialog):
+        css_provider = None
+        def __init__(self, *, mode, image, rows, columns, goal):
+            Gtk.Dialog.__init__(self)
+            self.selected_indices = set()
+            self.indices = []
+            self.mode = mode
+            self.columns = columns
+            self.goal = goal \
+                .replace("<strong>", '\n<span size="xx-large">') \
+                .replace("</strong>", "</span>")
+
+            self.set_title("CAPTCHA Challenge")
+            self.set_icon_name('view-refresh-symbolic')
+            self.verify = self.add_button("", Gtk.ResponseType.OK)
+            context = self.verify.get_style_context()
+            context.add_class("suggested-action")
+            self.set_resizable(False)
+            content = self.get_content_area()
+            content.set_spacing(6)
+            for dir in ["top", "right", "bottom", "left"]:
+                getattr(content, "set_margin_" + dir)(6)
+
+            self.header = Gtk.Label.new("")
+            self.header.set_xalign(0)
+            context = self.header.get_style_context()
+            context.add_class("challenge-header")
+            content.pack_start(self.header, False, False, 0)
+
+            pixbuf = image_to_gdk_pixbuf(image)
+            stride_x = image.width // columns
+            stride_y = image.height // rows
+
+            self.grid = Gtk.Grid.new()
+            for i in range(rows * columns):
+                self.indices.append(i)
+                column = i % columns
+                row = i // columns
+
+                cell_pixbuf = GdkPixbuf.Pixbuf.new(
+                        GdkPixbuf.Colorspace.RGB, pixbuf.get_has_alpha(),
+                        8, stride_x, stride_y)
+                src_x = stride_x * column
+                src_y = stride_y * row
+                pixbuf.copy_area(src_x, src_y, stride_x, stride_y,
+                        cell_pixbuf, 0, 0)
+                if mode == "multicaptcha":
+                    button = ChallengeButton(cell_pixbuf)
+                    button.connect("toggled", lambda obj: self.toggle_index(obj))
+                elif mode == "dynamic":
+                    button = Gtk.Button.new()
+                    image = Gtk.Image.new_from_pixbuf(cell_pixbuf)
+                    button.add(image)
+                    button.connect("clicked",
+                            lambda obj: self.emit("tile-clicked", obj.i))
+                button.i = i
+                context = button.get_style_context()
+                context.add_class("challenge-button")
+                self.grid.attach(button, column, row, 1, 1)
+
+            content.pack_start(self.grid, True, True, 0)
+            self.update_status()
+            if ChallengeDialog.css_provider is None:
+                ChallengeDialog.css_provider = Gtk.CssProvider.new()
+                ChallengeDialog.css_provider.load_from_data(bytes("""
+                    .challenge-button {
+                        border-radius: 0;
+                        border-width: 1px;
+                        padding: 0;
+                    }
+                    .challenge-check, .challenge-header {
+                        color: @theme_selected_fg_color;
+                        background-image: linear-gradient(
+                            @theme_selected_bg_color, @theme_selected_bg_color);
+                    }
+                    .challenge-header {
+                        padding: 12px;
+                    }
+                    .challenge-check {
+                        border-radius: 50%;
+                    }
+                    """, "utf-8"))
+                Gtk.StyleContext.add_provider_for_screen(
+                        Gdk.Screen.get_default(), ChallengeDialog.css_provider,
+                        Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+
+
+        @GObject.Signal(name="tile-clicked", arg_types=(int,))
+        def do_tile_clicked(self, i):
+            column = i % self.columns
+            row = i // self.columns
+            button = self.grid.get_child_at(column, row)
+            spinner = Gtk.Spinner.new()
+            spinner.set_size_request(32, 32)
+            left = (button.get_allocated_width() - 32) / 2
+            top = (button.get_allocated_height() - 32) / 2
+            spinner.set_margin_top(math.floor(top))
+            spinner.set_margin_left(math.floor(left))
+            spinner.set_margin_bottom(math.ceil(top))
+            spinner.set_margin_right(math.ceil(left))
+            self.grid.remove(button)
+            self.grid.attach(spinner, column, row, 1, 1)
+            spinner.show()
+            spinner.start()
+
+        def get_current_index(self, i):
+            return self.indices[i]
+
+        def replace_image(self, index, new_index, pixbuf):
+            i = self.indices.index(index)
+            self.selected_indices.add(index)
+            column = i % self.columns
+            row = i // self.columns
+            spinner = self.grid.get_child_at(column, row)
+            if pixbuf is None:
+                spinner.stop()
+            else:
+                self.grid.remove(spinner)
+                button = Gtk.Button.new()
+                button.i = i
+                image = Gtk.Image.new_from_pixbuf(pixbuf)
+                button.add(image)
+                button.connect("clicked", lambda obj: self.emit('tile-clicked', obj.i))
+                context = button.get_style_context()
+                context.add_class("challenge-button")
+                self.grid.attach(button, column, row, 1, 1)
+                button.show_all()
+                self.indices[i] = new_index
+
+        def toggle_index(self, button):
+            index = self.indices[button.i]
+            if button.get_active():
+                self.selected_indices.add(index)
+            else:
+                self.selected_indices.remove(index)
+            self.update_status()
+
+        def update_status(self):
+            markup = self.goal + "\n"
+            button_text = "Ver_ify"
+            if self.mode == "multicaptcha":
+                note = "If there are none, click skip"
+                if len(self.selected_indices) > 0:
+                    note = '<span alpha="30%">{}</span>'.format(note)
+                else:
+                    button_text = "Sk_ip"
+            elif self.mode == "dynamic":
+                note = "Click verify once there are none left"
+            self.header.set_markup(markup + note)
+            self.verify.set_label(button_text)
+
+        def run_challenge(self):
+            self.show_all()
+            response = self.run()
+            self.destroy()
+            while Gtk.events_pending():
+                Gtk.main_iteration()
+            if response == Gtk.ResponseType.OK:
+                return list(self.selected_indices)
+            return None
 
 class Solver:
     def __init__(self, recaptcha):
@@ -238,7 +451,6 @@ class Solver:
             proc.terminate()
         self._image_procs.clear()
 
-
 class DynamicSolver(Solver):
     def __init__(self, recaptcha, pmeta):
         super().__init__(recaptcha)
@@ -246,6 +458,7 @@ class DynamicSolver(Solver):
         self.selections = []
 
         meta = get_meta(pmeta, 1)
+        self.challenge_id = meta[0]
         self.num_rows = meta[3]
         self.num_columns = meta[4]
         self.num_tiles = self.num_rows * self.num_columns
@@ -253,10 +466,56 @@ class DynamicSolver(Solver):
         self.rc.print_challenge_goal(meta)
 
     def run(self):
-        self.first_payload()
-        for index in self.original_selections:
-            self.select_tile(index)
-        return self.selections
+        if Gtk:
+            image = get_image(self.rc.get("payload", api=False, params={
+                "c": self.rc.current_token,
+                "k": self.rc.api_key,
+            }).content)
+            self.dialog = ChallengeDialog(mode="dynamic", image=image,
+                    rows=self.num_rows, columns=self.num_columns,
+                    goal=self.rc.find_challenge_goal(self.challenge_id))
+
+            self.last_request_time = time.monotonic()
+
+            self.dialog.connect("tile-clicked",
+                    lambda obj, i: self.queue_replace_tile(i))
+
+            return self.dialog.run_challenge()
+        else:
+            self.first_payload()
+            for index in self.original_selections:
+                self.select_tile(index)
+            return self.selections
+
+    def queue_replace_tile(self, i):
+        index = self.dialog.get_current_index(i)
+        self.current_index += 1
+        new_index = self.current_index
+
+        def do_replace(pixbuf):
+            self.dialog.replace_image(index, new_index, pixbuf)
+            return False
+
+        # runs on the worker thread
+        def finish_replace(sess, resp):
+            if resp is not None:
+                resp.raise_for_status()
+                image = get_image(resp.content)
+                pixbuf = image_to_gdk_pixbuf(image)
+            else:
+                pixbuf = None
+            # call back to gtk in the main thread
+            GLib.timeout_add(0, lambda: do_replace(pixbuf))
+
+        def start_replace():
+            self.get_replace_image(index, callback=finish_replace)
+            return False
+
+        now = time.monotonic()
+        next_request_time = self.last_request_time + DYNAMIC_SELECT_DELAY
+        wait_duration = max(next_request_time - now, 0)
+        self.last_request_time = now + wait_duration
+        GLib.timeout_add(wait_duration * 1000, start_replace)
 
     def first_payload(self):
         image = get_image(self.rc.get("payload", api=False, params={
@@ -295,32 +554,58 @@ class DynamicSolver(Solver):
             time.sleep(sleep_duration)
             current_index = self.current_index
 
+    def get_replace_image(self, index, callback=None):
+        def get_payload(resp):
+            resp.raise_for_status()
+            self.rc.debug("[http] [post] [response] {}".format(resp.text))
+            data = load_rc_json(resp.text)
+
+            self.rc.current_token = data[1]
+            if len(data[2]) == 0:
+                if callback is not None:
+                    return callback(None, None)
+                else:
+                    return None
+            replacement_id = data[2][0]
+            params = {
+                "c": self.rc.current_token,
+                "k": self.rc.api_key,
+                "id": replacement_id,
+            }
+
+            if callback is not None:
+                return self.rc.get_async("payload", api=False, params=params,
+                        background_callback=callback)
+            return get_image(
+                    self.rc.get("payload", api=False, params=params).content)
+
+        postdata = {
+            "c": self.rc.current_token,
+            "ds": "[{}]".format(index)
+        }
+        if callback is not None:
+            # use timeout_add to put it back on the main thread
+            return self.rc.post_async("replaceimage", data=postdata,
+                    background_callback=
+                        lambda s, r: GLib.timeout_add(0, get_payload(r)))
+        r = self.rc.post("replaceimage", data=postdata, no_debug_response=True)
+        return get_payload(r)
+
+
     def tile_iteration(self, index):
         self.selections.append(index)
-        r = self.rc.post("replaceimage", data={
-            "c": self.rc.current_token,
-            "ds": "[{}]".format(index),
-        })
-
-        data = load_rc_json(r.text)
         self.current_index += 1
+        image = self.get_replace_image(index)
+        if image is not None:
+            self.show_image(image)
 
-        self.rc.current_token = data[1]
-        replacement_id = data[2][0]
-
-        image = get_image(self.rc.get("payload", api=False, params={
-            "c": self.rc.current_token,
-            "k": self.rc.api_key,
-            "id": replacement_id,
-        }).content)
-        self.show_image(image)
-
-        print("Take a look at the image that just appeared.")
-        selected = input(
-            "Should this image be selected? [y/N] ",
-        )[:1].lower() == "y"
-        self.hide_images()
-        return selected
+            print("Take a look at the image that just appeared.")
+            selected = input(
+                "Should this image be selected? [y/N] ",
+            )[:1].lower() == "y"
+            self.hide_images()
+            return selected
+        return False
 
 
 class MultiCaptchaSolver(Solver):
@@ -348,6 +633,7 @@ class MultiCaptchaSolver(Solver):
 
     def next_challenge(self):
         meta = self.metas.pop(0)
+        self.challenge_id = meta[0]
         self.num_rows = meta[3]
         self.num_columns = meta[4]
         self.num_tiles = self.num_rows * self.num_columns
@@ -365,8 +651,8 @@ class MultiCaptchaSolver(Solver):
             "Enter numbers separated by spaces: ", self.num_tiles,
         )
         self.hide_images()
-        self.selection_groups.append(list(sorted(indices)))
         print()
+        return list(indices)
 
     def show_image(self, image):
         draw_lines(image, self.num_rows, self.num_columns)
@@ -378,10 +664,27 @@ class MultiCaptchaSolver(Solver):
             "c": self.rc.current_token,
             "k": self.rc.api_key,
         }).content)
-        self.show_image(image)
-        self.get_answer()
+        self.prompt(image)
+
+    def prompt(self, image):
+        if Gtk:
+            dialog = ChallengeDialog(
+                    mode="multicaptcha", image=image,
+                    rows=self.num_rows, columns=self.num_columns,
+                    goal=self.rc.find_challenge_goal(self.challenge_id))
+            indices = dialog.run_challenge()
+        else:
+            self.show_image(image)
+            indices = self.get_answer()
+        if indices is None:
+            self.selection_groups = None
+        else:
+            self.selection_groups.append(sorted(indices))
 
     def replace_image(self):
+        if self.selection_groups is None:
+            self.metas = None
+            return
         selections = self.selection_groups[-1]
         r = self.rc.post("replaceimage", data={
             "c": self.rc.current_token,
@@ -402,8 +705,7 @@ class MultiCaptchaSolver(Solver):
             "k": self.rc.api_key,
             "id": self.previous_id,
         }).content)
-        self.show_image(image)
-        self.get_answer()
+        self.prompt(image)
 
 
 class ReCaptcha:
@@ -417,6 +719,8 @@ class ReCaptcha:
         self.first_token = None
         self.current_token = None
         self.user_agent = user_agent or random_user_agent()
+        if FuturesSession:
+            self.session = FuturesSession()
 
         self.js_strings = None
         self.rc_version = None
@@ -446,22 +750,40 @@ class ReCaptcha:
             goal = min(matching_strings)[2]
         except ValueError:
             return None
-        return goal.replace("<strong>", "").replace("</strong>", "")
+        return goal
 
     def print_challenge_goal(self, meta):
         print("Challenge information: {}".format(json.dumps(meta)))
-        goal = self.find_challenge_goal(meta[0])
-        print(
-            "Could not determine challenge objective. See the challenge "
-            "information above for more information."
-            if goal is None else "CHALLENGE OBJECTIVE: {}".format(goal)
-        )
+        if not Gtk:
+            goal = self.find_challenge_goal(meta[0])
+            goal = goal.replace("<strong>", "").replace("</strong>", "")
+            print(
+                "Could not determine challenge objective. See the challenge "
+                "information above for more information."
+                if goal is None else "CHALLENGE OBJECTIVE: {}".format(goal)
+            )
 
     def get_headers(self, headers):
         headers = headers or {}
         if "User-Agent" not in headers:
             headers["User-Agent"] = self.user_agent
         return headers
+
+    def get_async(self, url, *, params=None, api=True, headers=None,
+            **kwargs):
+        params = params or {}
+        if api:
+            params["k"] = self.api_key
+            params["v"] = self.rc_version
+        headers = self.get_headers(headers)
+
+        full_url = get_full_url(url)
+        r = self.session.get(
+            full_url, params=params, headers=headers, **kwargs,
+        )
+
+        self.debug("[http] [get] {}".format(full_url))
+        return r
 
     def get(self, url, *, params=None, api=True, headers=None,
             allow_errors=None, **kwargs):
@@ -478,6 +800,25 @@ class ReCaptcha:
         self.debug("[http] [get] {}".format(r.url))
         if not (allow_errors is True or r.status_code in (allow_errors or {})):
             r.raise_for_status()
+        return r
+
+    def post_async(self, url, *, params=None, data=None, api=True, headers=None,
+              **kwargs):
+        params = params or {}
+        data = data or {}
+        if api:
+            params["k"] = self.api_key
+            data["v"] = self.rc_version
+        headers = self.get_headers(headers)
+
+        full_url = get_full_url(url)
+        r = self.session.post(
+            full_url, params=params, data=data, headers=headers,
+            **kwargs,
+        )
+
+        self.debug("[http] [post] {}".format(full_url))
+        self.debug("[http] [post] [data] {!r}".format(data))
         return r
 
     def post(self, url, *, params=None, data=None, api=True, headers=None,
@@ -529,7 +870,7 @@ class ReCaptcha:
         response_text = json.dumps({"response": response}, separators=",:")
         response_b64 = rc_base64(response_text)
 
-        self.debug("Sending verify request...")
+        self.debug("Sending verify request: {!r}".format(response_text))
         r = self.post("userverify", data={
             "c": self.current_token,
             "response": response_b64,
@@ -546,7 +887,13 @@ class ReCaptcha:
         self.request_first_token()
         rresp = self.get_first_rresp()
         while rresp is not None:
-            uv_token, rresp = self.solve_challenge(rresp)
+            try:
+                uv_token, rresp = self.solve_challenge(rresp)
+            except requests.HTTPError as e:
+                if e.response.status_code == 410:
+                    rresp = ()
+                else:
+                    raise e
             if rresp is not None:
                 print("You must solve another challenge.")
                 print()
@@ -563,8 +910,9 @@ class ReCaptcha:
         challenge_type = rresp[5]
         self.debug("Challenge type: {}".format(challenge_type))
 
-        if challenge_type == "default":
-            print('ERROR: Received challenge type "default".')
+        if challenge_type == "default" or challenge_type == "doscaptcha":
+            print('ERROR: Received challenge type "{}".'
+                    .format(challenge_type))
             print("This is usually an indication that reCAPTCHA requests from "
                   "this network are being blocked.")
             print("Try installing Tor (the full installation, not just the "
@@ -596,6 +944,8 @@ class ReCaptcha:
 
         solver = solver_class(self, pmeta)
         response = solver.run()
+        if response is None:
+            return (None, None)
         return self.verify(response)
 
 

--- a/setup.py
+++ b/setup.py
@@ -68,4 +68,7 @@ setup(
         "requests>=2.18.1",
         "slimit>=0.8.1",
     ],
+    extras_require={
+        'gtk': ['PyGObject>=3.30.0', 'requests-futures>=0.9.7']
+    }
 )


### PR DESCRIPTION
Works similar to the standard javascript captcha that google provides. If the optional dependencies are installed the GTK widget will show, otherwise it will fall back to the text-based interface. The optional dependencies (PyGObject, requests-futures) can be installed via:

```
pip3 install .[gtk]
pip3 install librecaptcha[gtk] # when installing from pypi
```

Here's a screenshot:

![Screenshot](https://user-images.githubusercontent.com/43323938/46892185-0de19200-ce5c-11e8-911f-bcef0f6813dc.png)
